### PR TITLE
LWOTC: Item use check tweaks

### DIFF
--- a/worlds/x2wotc/mods/lwotc/__init__.py
+++ b/worlds/x2wotc/mods/lwotc/__init__.py
@@ -362,6 +362,18 @@ config: dict[str, str] = {
         +CheckUseItems=RedscreenRounds
         +CheckUseItems=NeedleRounds
         +CheckUseItems=FalconRounds
+
+        +CheckUseItemExcludeAbilities=Suppression_LW
+        +CheckUseItemIncludeAbilities=SuppressionShot_LW
+        +CheckUseItemExcludeAbilities=AreaSuppression
+        +CheckUseItemIncludeAbilities=AreaSuppressionShot_LW
+        +CheckUseItemExcludeAbilities=LeadTheTarget_LW
+        +CheckUseItemIncludeAbilities=LeadTheTargetShot_LW
+        +CheckUseItemExcludeAbilities=Stock_LW_Bsc_Ability
+        +CheckUseItemExcludeAbilities=Stock_LW_Adv_Ability
+        +CheckUseItemExcludeAbilities=Stock_LW_Sup_Ability
+        +CheckUseItemExcludeAbilities=Gunslinger
+        +CheckUseItemIncludeAbilities=GunslingerShot
         """
     )
 }

--- a/worlds/x2wotc/mods/lwotc/__init__.py
+++ b/worlds/x2wotc/mods/lwotc/__init__.py
@@ -348,6 +348,14 @@ config: dict[str, str] = {
         +CheckUseItems=GasGrenadeMk2
         +CheckUseItems=FirebombMk2
         +CheckUseItems=AcidGrenadeMk2
+        +CheckUseItemCategories=(CategoryName=ShredderGun, \\
+            Members[0]=ShredderGun, \\
+            Members[1]=ShredstormCannon \\
+        )
+        +CheckUseItemCategories=(CategoryName=PrototypePlasmaBlaster, \\
+            Members[0]=PrototypePlasmaBlaster, \\
+            Members[1]=PlasmaBlaster \\
+        )
         +CheckUseItems=PrototypePlasmaBlaster
         +CheckUseItems=PlasmaBlaster
         +CheckUseItems=ShredderGun

--- a/worlds/x2wotc/mods/lwotc/__init__.py
+++ b/worlds/x2wotc/mods/lwotc/__init__.py
@@ -333,29 +333,14 @@ config: dict[str, str] = {
     "X2Effect_ItemUseCheck": dedent(
         r"""
         +CheckUseItems=ShapedCharge
-        +CheckUseItemCategories=(CategoryName=GasGrenade, \\
-            Members[0]=GasGrenade, \\
-            Members[1]=GasGrenadeMk2 \\
-        )
-        +CheckUseItemCategories=(CategoryName=Firebomb, \\
-            Members[0]=Firebomb, \\
-            Members[1]=FirebombMk2 \\
-        )
-        +CheckUseItemCategories=(CategoryName=AcidGrenade, \\
-            Members[0]=AcidGrenade, \\
-            Members[1]=AcidGrenadeMk2 \\
-        )
+        +CheckUseItemCategories=(CategoryName=GasGrenade, Members[0]=GasGrenadeMk2)
+        +CheckUseItemCategories=(CategoryName=Firebomb, Members[0]=FirebombMk2)
+        +CheckUseItemCategories=(CategoryName=AcidGrenade, Members[0]=AcidGrenadeMk2)
         +CheckUseItems=GasGrenadeMk2
         +CheckUseItems=FirebombMk2
         +CheckUseItems=AcidGrenadeMk2
-        +CheckUseItemCategories=(CategoryName=ShredderGun, \\
-            Members[0]=ShredderGun, \\
-            Members[1]=ShredstormCannon \\
-        )
-        +CheckUseItemCategories=(CategoryName=PrototypePlasmaBlaster, \\
-            Members[0]=PrototypePlasmaBlaster, \\
-            Members[1]=PlasmaBlaster \\
-        )
+        +CheckUseItemCategories=(CategoryName=ShredderGun, Members[0]=ShredstormCannon)
+        +CheckUseItemCategories=(CategoryName=PrototypePlasmaBlaster, Members[0]=PlasmaBlaster)
         +CheckUseItems=PrototypePlasmaBlaster
         +CheckUseItems=PlasmaBlaster
         +CheckUseItems=ShredderGun


### PR DESCRIPTION
* Grant Prototype Plasma Blaster check when using Plasma Blaster, and Shredder Gun check when using Shredstorm Cannon
* Account for LWOTC abilities in ammo use checks