### PR TITLE
Push The Lost kill check later in LWOTC

### DIFF
--- a/worlds/x2wotc/mods/lwotc/__init__.py
+++ b/worlds/x2wotc/mods/lwotc/__init__.py
@@ -220,7 +220,7 @@ def generate_early(world: "X2WOTCWorld"):
         ("KillViperKing", 90.0),
         ("KillBerserkerQueen", 90.0),
         ("KillArchonKing", 90.0),
-        ("KillTheLost", fl_to_diff(5)),
+        ("KillTheLost", fl_to_diff(10)),
         ("UseBattleScanner", fl_to_diff_pg(1)),
         ("UseNanoMedikit", fl_to_diff_pg(3)),
         ("UseEMPGrenade", fl_to_diff_pg(4)),


### PR DESCRIPTION
Because The Lost are found somewhat unreliably in LWOTC, push the respective kill check to a later point in the campaign.
