### PR TITLE
Apply LWOTC loc changes to item/location translation tables

### DIFF
--- a/worlds/x2wotc/Proxy.py
+++ b/worlds/x2wotc/Proxy.py
@@ -277,7 +277,6 @@ def handle_tick(layer: str, number_received: int) -> str:
         response_body += "\n\n"
 
         item_data = item_table[item_name]
-        item_name = mod_item_map(item_name)
 
         # Info for the game to process
         if item_data.stages is None:

--- a/worlds/x2wotc/Proxy.py
+++ b/worlds/x2wotc/Proxy.py
@@ -43,6 +43,22 @@ def get_slot_info(slot: int) -> NetworkSlot | None:
         logger.debug(f"Proxy: No slot {slot}")
         return None
 
+# Resolve APworld mod location mapping
+def mod_loc_map(loc_name: str) -> str:
+    for mod_data in reversed(mods_data):
+        if mod_data.name in ctx.active_mods and loc_name in mod_data.location_map:
+            loc_name = mod_data.location_map[loc_name]
+            break
+    return loc_name
+
+# Resolve APWorld mod item mapping
+def mod_item_map(item_name: str) -> str:
+    for mod_data in reversed(mods_data):
+        if mod_data.name in ctx.active_mods and item_name in mod_data.item_map:
+            item_name = mod_data.item_map[item_name]
+            break
+    return item_name
+
 # ----------------------------------------------------- SCOUT -------------------------------------------------------- #
 
 async def scout_loop():
@@ -116,13 +132,6 @@ def get_locations_info(checks: list[str]) -> LocationsInfo:
 
 async def send_checks(checks: list[str], connected: bool = True):
     for loc_name in checks:
-
-        # Resolve APworld mod location mapping
-        for mod_data in reversed(mods_data):
-            if mod_data.name in ctx.active_mods and loc_name in mod_data.location_map:
-                loc_name = mod_data.location_map[loc_name]
-                break
-
         try:
             loc_id = location_table[loc_name].id
         except KeyError:
@@ -183,12 +192,6 @@ def get_received_items(layer: str, number_received: int) -> ItemsInfo:
                 if stage is not None:
                     item_name = stage
 
-        # Resolve APWorld mod item mapping
-        for mod_data in reversed(mods_data):
-            if mod_data.name in ctx.active_mods and item_name in mod_data.item_map:
-                item_name = mod_data.item_map[item_name]
-                break
-
         slot_info = get_slot_info(network_item.player)
         items_info.append((item_name, network_item, slot_info))
 
@@ -202,6 +205,7 @@ def get_received_items(layer: str, number_received: int) -> ItemsInfo:
 
 async def handle_check(request: web.Request):
     checks = [check for check in request.match_info["tail"].split("/") if check != ""]
+    checks = [mod_loc_map(check) for check in checks]
 
     if not ctx.connected.is_set():
         await send_checks(checks, connected=False)
@@ -274,6 +278,7 @@ def handle_tick(layer: str, number_received: int) -> str:
         response_body += "\n\n"
 
         item_data = item_table[item_name]
+        item_name = mod_item_map(item_name)
 
         # Info for the game to process
         if item_data.stages is None:

--- a/worlds/x2wotc/mods/lwotc/Items.py
+++ b/worlds/x2wotc/mods/lwotc/Items.py
@@ -1,6 +1,6 @@
 from BaseClasses import ItemClassification as IC
 
-from worlds.x2wotc.ItemData import X2WOTCItemData, TECH_ITEM_PREFIX, PCS_ITEM_PREFIX, get_new_item_id
+from worlds.x2wotc.ItemData import X2WOTCItemData, TECH_ITEM_PREFIX, PCS_ITEM_PREFIX, WEAPON_MOD_ITEM_PREFIX, get_new_item_id
 
 
 # For the full definition of X2WOTCItemData, see worlds/x2wotc/ItemData.py
@@ -22,6 +22,15 @@ lwotc_items: dict[str, X2WOTCItemData] = {
         tags = {"weapon"},
         power = 50.0,
         normal_location = "AdvancedLasers"
+    ),
+    "_GaussWeaponsCompleted_LW": X2WOTCItemData(
+        display_name = TECH_ITEM_PREFIX + "Advanced Magnetic Weapons",
+        id = get_new_item_id(),
+        classification = IC.progression | IC.useful,
+        type = "TechCompleted",
+        tags = {"weapon"},
+        power = 100.0,
+        normal_location = "_GaussWeapons_LW"
     ),
     "CoilgunsCompleted": X2WOTCItemData(
         display_name = TECH_ITEM_PREFIX + "Coilguns",
@@ -169,7 +178,7 @@ lwotc_items: dict[str, X2WOTCItemData] = {
     ),
 }
 
-lwotc_filler_items: dict[str, X2WOTCItemData] = {
+lwotc_pcs_items: dict[str, X2WOTCItemData] = {
     "DepthPerceptionPCS:1": X2WOTCItemData(
         display_name = PCS_ITEM_PREFIX + "Depth Perception",
         id = get_new_item_id(),
@@ -299,7 +308,74 @@ lwotc_filler_items: dict[str, X2WOTCItemData] = {
     ),
 }
 
+lwotc_weapon_mod_items: dict[str, X2WOTCItemData] = {
+    "_AimUpgrade_Sup_LW:1": X2WOTCItemData(
+        display_name = WEAPON_MOD_ITEM_PREFIX + "Elite Scope",
+        id = get_new_item_id(),
+        classification = IC.useful,
+        type = "Resource",
+        tags = {"filler", "weapon_mod", "scope", "superior"}
+    ),
+    "_CritUpgrade_Sup_LW:1": X2WOTCItemData(
+        display_name = WEAPON_MOD_ITEM_PREFIX + "Elite Laser Sight",
+        id = get_new_item_id(),
+        classification = IC.useful,
+        type = "Resource",
+        tags = {"filler", "weapon_mod", "laser_sight", "superior"}
+    ),
+    "_ReloadUpgrade_Sup_LW:1": X2WOTCItemData(
+        display_name = WEAPON_MOD_ITEM_PREFIX + "Elite Auto-Loader",
+        id = get_new_item_id(),
+        classification = IC.useful,
+        type = "Resource",
+        tags = {"filler", "weapon_mod", "auto_loader", "superior"}
+    ),
+    "_MissDamageUpgrade_Sup_LW:1": X2WOTCItemData(
+        display_name = WEAPON_MOD_ITEM_PREFIX + "Elite Stock",
+        id = get_new_item_id(),
+        classification = IC.useful,
+        type = "Resource",
+        tags = {"filler", "weapon_mod", "stock", "superior"}
+    ),
+    "_FreeFireUpgrade_Sup_LW:1": X2WOTCItemData(
+        display_name = WEAPON_MOD_ITEM_PREFIX + "Elite Hair Trigger",
+        id = get_new_item_id(),
+        classification = IC.useful,
+        type = "Resource",
+        tags = {"filler", "weapon_mod", "hair_trigger", "superior"}
+    ),
+    "_ClipSizeUpgrade_Sup_LW:1": X2WOTCItemData(
+        display_name = WEAPON_MOD_ITEM_PREFIX + "Elite Expanded Magazine",
+        id = get_new_item_id(),
+        classification = IC.useful,
+        type = "Resource",
+        tags = {"filler", "weapon_mod", "expanded_magazine", "superior"}
+    ),
+    "_FreeKillUpgrade_Bsc_LW:1": X2WOTCItemData(
+        display_name = WEAPON_MOD_ITEM_PREFIX + "Basic Suppressor",
+        id = get_new_item_id(),
+        classification = IC.useful,
+        type = "Resource",
+        tags = {"filler", "weapon_mod", "repeater", "basic"}
+    ),
+    "_FreeKillUpgrade_Adv_LW:1": X2WOTCItemData(
+        display_name = WEAPON_MOD_ITEM_PREFIX + "Advanced Suppressor",
+        id = get_new_item_id(),
+        classification = IC.useful,
+        type = "Resource",
+        tags = {"filler", "weapon_mod", "repeater", "advanced"}
+    ),
+    "_FreeKillUpgrade_Sup_LW:1": X2WOTCItemData(
+        display_name = WEAPON_MOD_ITEM_PREFIX + "Elite Suppressor",
+        id = get_new_item_id(),
+        classification = IC.useful,
+        type = "Resource",
+        tags = {"filler", "weapon_mod", "repeater", "superior"}
+    ),
+}
+
 items: dict[str, X2WOTCItemData] = {
     **lwotc_items,
-    **lwotc_filler_items
+    **lwotc_pcs_items,
+    **lwotc_weapon_mod_items,
 }

--- a/worlds/x2wotc/mods/lwotc/Items.py
+++ b/worlds/x2wotc/mods/lwotc/Items.py
@@ -266,7 +266,7 @@ lwotc_pcs_items: dict[str, X2WOTCItemData] = {
         id = get_new_item_id(),
         type = "Resource",
         classification = IC.useful,
-        tags = {"filler", "pcs", "superior", "defense"},
+        tags = {"filler", "pcs", "superior", "elite", "defense"},
     ),
     "CommonPCSPsi:1": X2WOTCItemData(
         display_name = PCS_ITEM_PREFIX + "Basic Psi",
@@ -285,7 +285,7 @@ lwotc_pcs_items: dict[str, X2WOTCItemData] = {
         id = get_new_item_id(),
         type = "Resource",
         classification = IC.useful,
-        tags = {"filler", "pcs", "superior", "psi"},
+        tags = {"filler", "pcs", "superior", "elite", "psi"},
     ),
     "CommonPCSHacking:1": X2WOTCItemData(
         display_name = PCS_ITEM_PREFIX + "Basic Hacking",
@@ -304,7 +304,7 @@ lwotc_pcs_items: dict[str, X2WOTCItemData] = {
         id = get_new_item_id(),
         type = "Resource",
         classification = IC.useful,
-        tags = {"filler", "pcs", "superior", "hacking"},
+        tags = {"filler", "pcs", "superior", "elite", "hacking"},
     ),
 }
 
@@ -314,63 +314,61 @@ lwotc_weapon_mod_items: dict[str, X2WOTCItemData] = {
         id = get_new_item_id(),
         classification = IC.useful,
         type = "Resource",
-        tags = {"filler", "weapon_mod", "scope", "superior"}
+        tags = {"filler", "weapon_mod", "scope", "superior", "elite"}
     ),
     "_CritUpgrade_Sup_LW:1": X2WOTCItemData(
         display_name = WEAPON_MOD_ITEM_PREFIX + "Elite Laser Sight",
         id = get_new_item_id(),
         classification = IC.useful,
         type = "Resource",
-        tags = {"filler", "weapon_mod", "laser_sight", "superior"}
+        tags = {"filler", "weapon_mod", "laser_sight", "superior", "elite"}
     ),
     "_ReloadUpgrade_Sup_LW:1": X2WOTCItemData(
         display_name = WEAPON_MOD_ITEM_PREFIX + "Elite Auto-Loader",
         id = get_new_item_id(),
         classification = IC.useful,
         type = "Resource",
-        tags = {"filler", "weapon_mod", "auto_loader", "superior"}
+        tags = {"filler", "weapon_mod", "auto_loader", "superior", "elite"}
     ),
     "_MissDamageUpgrade_Sup_LW:1": X2WOTCItemData(
         display_name = WEAPON_MOD_ITEM_PREFIX + "Elite Stock",
         id = get_new_item_id(),
         classification = IC.useful,
         type = "Resource",
-        tags = {"filler", "weapon_mod", "stock", "superior"}
+        tags = {"filler", "weapon_mod", "stock", "superior", "elite"}
     ),
     "_FreeFireUpgrade_Sup_LW:1": X2WOTCItemData(
         display_name = WEAPON_MOD_ITEM_PREFIX + "Elite Hair Trigger",
         id = get_new_item_id(),
         classification = IC.useful,
         type = "Resource",
-        tags = {"filler", "weapon_mod", "hair_trigger", "superior"}
+        tags = {"filler", "weapon_mod", "hair_trigger", "superior", "elite"}
     ),
     "_ClipSizeUpgrade_Sup_LW:1": X2WOTCItemData(
         display_name = WEAPON_MOD_ITEM_PREFIX + "Elite Expanded Magazine",
         id = get_new_item_id(),
         classification = IC.useful,
         type = "Resource",
-        tags = {"filler", "weapon_mod", "expanded_magazine", "superior"}
+        tags = {"filler", "weapon_mod", "expanded_magazine", "superior", "elite"}
     ),
     "_FreeKillUpgrade_Bsc_LW:1": X2WOTCItemData(
         display_name = WEAPON_MOD_ITEM_PREFIX + "Basic Suppressor",
         id = get_new_item_id(),
-        classification = IC.useful,
         type = "Resource",
-        tags = {"filler", "weapon_mod", "repeater", "basic"}
+        tags = {"filler", "weapon_mod", "repeater", "suppressor", "basic"}
     ),
     "_FreeKillUpgrade_Adv_LW:1": X2WOTCItemData(
         display_name = WEAPON_MOD_ITEM_PREFIX + "Advanced Suppressor",
         id = get_new_item_id(),
-        classification = IC.useful,
         type = "Resource",
-        tags = {"filler", "weapon_mod", "repeater", "advanced"}
+        tags = {"filler", "weapon_mod", "repeater", "suppressor", "advanced"}
     ),
     "_FreeKillUpgrade_Sup_LW:1": X2WOTCItemData(
         display_name = WEAPON_MOD_ITEM_PREFIX + "Elite Suppressor",
         id = get_new_item_id(),
         classification = IC.useful,
         type = "Resource",
-        tags = {"filler", "weapon_mod", "repeater", "superior"}
+        tags = {"filler", "weapon_mod", "repeater", "suppressor", "superior", "elite"}
     ),
 }
 

--- a/worlds/x2wotc/mods/lwotc/Locations.py
+++ b/worlds/x2wotc/mods/lwotc/Locations.py
@@ -77,12 +77,21 @@ lwotc_techs: dict[str, X2WOTCLocationData] = {
         difficulty = fl_to_diff(5),
         normal_item = "AdvancedLasersCompleted"
     ),
+    "_GaussWeapons_LW": X2WOTCLocationData(
+        display_name = TECH_LOCATION_PREFIX + "Advanced Magnetic Weapons",
+        id = get_new_location_id(),
+        layer = "Strategy",
+        type = "Tech",
+        tags = {"tree:MagnetizedWeapons"},
+        difficulty = fl_to_diff(9),
+        normal_item = "_GaussWeaponsCompleted_LW"
+    ),
     "Coilguns": X2WOTCLocationData(
         display_name = TECH_LOCATION_PREFIX + "Coilguns",
         id = get_new_location_id(),
         layer = "Strategy",
         type = "Tech",
-        tags = {"tree:GaussWeapons"},
+        tags = {"tree:_GaussWeapons_LW", "tree:Tech_Elerium"},
         difficulty = fl_to_diff(13),
         normal_item = "CoilgunsCompleted"
     ),

--- a/worlds/x2wotc/mods/lwotc/__init__.py
+++ b/worlds/x2wotc/mods/lwotc/__init__.py
@@ -7,7 +7,7 @@ from BaseClasses import ItemClassification as IC
 if TYPE_CHECKING:
     from worlds.x2wotc import X2WOTCWorld
 
-from .Items import items, lwotc_pcs_items, lwotc_weapon_mod_items, TECH_ITEM_PREFIX
+from .Items import items, lwotc_pcs_items, lwotc_weapon_mod_items
 from .Locations import locations, fl_to_diff, fl_to_diff_autopsy, fl_to_diff_pg, PG_GRENADE, PG_GRENADE_M2
 from .Rules import set_rules
 
@@ -112,17 +112,8 @@ def generate_early(world: "X2WOTCWorld"):
         "FreeKillUpgrade_Bsc:1",
         "FreeKillUpgrade_Adv:1",
         "FreeKillUpgrade_Sup:1",
-        "_AimUpgrade_Sup_LW:1",
-        "_CritUpgrade_Sup_LW:1",
-        "_ReloadUpgrade_Sup_LW:1",
-        "_MissDamageUpgrade_Sup_LW:1",
-        "_FreeFireUpgrade_Sup_LW:1",
-        "_ClipSizeUpgrade_Sup_LW:1",
-        "_FreeKillUpgrade_Bsc_LW:1",
-        "_FreeKillUpgrade_Adv_LW:1",
-        "_FreeKillUpgrade_Sup_LW:1",
     ])
-
+    world.item_manager.weapon_mod_items.update(set(lwotc_weapon_mod_items.keys()))
 
     # Rocket Launcher is a squaddie Technical skill
     world.loc_manager.disable_location("UseRocketLauncher")

--- a/worlds/x2wotc/mods/lwotc/__init__.py
+++ b/worlds/x2wotc/mods/lwotc/__init__.py
@@ -7,12 +7,27 @@ from BaseClasses import ItemClassification as IC
 if TYPE_CHECKING:
     from worlds.x2wotc import X2WOTCWorld
 
-from .Items import items, lwotc_filler_items
+from .Items import items, lwotc_pcs_items, lwotc_weapon_mod_items, TECH_ITEM_PREFIX
 from .Locations import locations, fl_to_diff, fl_to_diff_autopsy, fl_to_diff_pg, PG_GRENADE, PG_GRENADE_M2
 from .Rules import set_rules
 
 
 name = "Long War of the Chosen"
+location_map = {
+    "GaussWeapons": "_GaussWeapons_LW",
+}
+item_map = {
+    "_GaussWeaponsCompleted_LW": "GaussWeaponsCompleted",
+    "_AimUpgrade_Sup_LW:1": "AimUpgrade_Sup:1",
+    "_CritUpgrade_Sup_LW:1": "CritUpgrade_Sup:1",
+    "_ReloadUpgrade_Sup_LW:1": "ReloadUpgrade_Sup:1",
+    "_MissDamageUpgrade_Sup_LW:1": "MissDamageUpgrade_Sup:1",
+    "_FreeFireUpgrade_Sup_LW:1": "FreeFireUpgrade_Sup:1",
+    "_ClipSizeUpgrade_Sup_LW:1": "ClipSizeUpgrade_Sup:1",
+    "_FreeKillUpgrade_Bsc_LW:1": "FreeKillUpgrade_Bsc:1",
+    "_FreeKillUpgrade_Adv_LW:1": "FreeKillUpgrade_Adv:1",
+    "_FreeKillUpgrade_Sup_LW:1": "FreeKillUpgrade_Sup:1",
+}
 
 # For defining the order rules are applied in (in case of set_rule)
 # The order is lowest to highest priority
@@ -76,6 +91,33 @@ def generate_early(world: "X2WOTCWorld"):
             world.item_manager.item_table["AutopsyAdventTrooperCompleted"].display_name
         ] = 1
 
+    # Gauss Weapons is called Advanced Magnetic Weapons
+    world.loc_manager.disable_location("GaussWeapons")
+    world.item_manager.disable_item("GaussWeaponsCompleted")
+
+    # Repeaters are called Suppressors, Superior attachments are called Elite
+    world.item_manager.weapon_mod_items.difference_update([
+        "AimUpgrade_Sup:1",
+        "CritUpgrade_Sup:1",
+        "ReloadUpgrade_Sup:1",
+        "MissDamageUpgrade_Sup:1",
+        "FreeFireUpgrade_Sup:1",
+        "ClipSizeUpgrade_Sup:1",
+        "FreeKillUpgrade_Bsc:1",
+        "FreeKillUpgrade_Adv:1",
+        "FreeKillUpgrade_Sup:1",
+        "_AimUpgrade_Sup_LW:1",
+        "_CritUpgrade_Sup_LW:1",
+        "_ReloadUpgrade_Sup_LW:1",
+        "_MissDamageUpgrade_Sup_LW:1",
+        "_FreeFireUpgrade_Sup_LW:1",
+        "_ClipSizeUpgrade_Sup_LW:1",
+        "_FreeKillUpgrade_Bsc_LW:1",
+        "_FreeKillUpgrade_Adv_LW:1",
+        "_FreeKillUpgrade_Sup_LW:1",
+    ])
+
+
     # Rocket Launcher is a squaddie Technical skill
     world.loc_manager.disable_location("UseRocketLauncher")
 
@@ -94,8 +136,8 @@ def generate_early(world: "X2WOTCWorld"):
     # Force Level increases by off-world reinforcements which requires special handling
     world.item_manager.trap_items.discard("ForceLevel:1")
 
-    # Patch LWOTC fillers into item pool
-    world.item_manager.pcs_items.update(set(lwotc_filler_items.keys()))
+    # Patch LWOTC PCSes into item pool
+    world.item_manager.pcs_items.update(set(lwotc_pcs_items.keys()))
 
     for item, cat in [
         ("ModularWeaponsCompleted", IC.progression | IC.useful),
@@ -123,7 +165,7 @@ def generate_early(world: "X2WOTCWorld"):
         ("AutopsyViperKing", {"autopsy", "kill_ruler", "tree:AutopsyViper"}),
         ("AutopsyBerserkerQueen", {"autopsy", "kill_ruler", "tree:AutopsyBerserker"}),
         ("AutopsyArchonKing", {"autopsy", "kill_ruler", "tree:AutopsyArchon"}),
-        ("Tech_Elerium", {"tree:HybridMaterials", "tree:GaussWeapons", "tree:PlatedArmor"}),
+        ("Tech_Elerium", {"tree:HybridMaterials", "tree:_GaussWeapons_LW", "tree:PlatedArmor"}),
         ("UseBattleScanner", {"utility", "proving_ground", "item:HybridMaterialsCompleted"}),
         ("UseAlienGrenade", PG_GRENADE | {"item:AutopsyMutonCompleted"}),
         ("UseEMPGrenade", PG_GRENADE | {"item:AutopsyAdventMECCompleted"}),
@@ -146,7 +188,6 @@ def generate_early(world: "X2WOTCWorld"):
     for loc, diff in [
         ("Psionics", fl_to_diff(4)),
         ("MagnetizedWeapons", fl_to_diff(7)),
-        ("GaussWeapons", fl_to_diff(9)),
         ("PlatedArmor", fl_to_diff(9)),
         ("Tech_Elerium", fl_to_diff(11)),
         ("PlasmaRifle", fl_to_diff(17)),


### PR DESCRIPTION
Create new items and locations for things that have their localization changed by LWOTC:
* Gauss Weapons/Advanced Magnetic Weapons
* Repeaters/Suppressors
* Superior/Elite attachments

Additionally, add missing `Tech_Elerium` as Coilguns' prerequisite.