### PR TITLE
LWOTC: Fix Progressive Advanced Weapons

### DIFF
--- a/worlds/x2wotc/mods/lwotc/Items.py
+++ b/worlds/x2wotc/mods/lwotc/Items.py
@@ -85,7 +85,7 @@ lwotc_items: dict[str, X2WOTCItemData] = {
         tags = {"weapon", "progressive"},
         stages = [
             "AdvancedLasersCompleted",
-            "GaussWeaponsCompleted",
+            "_GaussWeaponsCompleted_LW",
             "AdvancedCoilgunsCompleted",
         ]
     ),


### PR DESCRIPTION
Grant the LWOTC version of Gauss Weapons (Advanced Magnetic Weapons) in progressive advanced weapons.

This bug caused generation to fail if LWOTC was enabled, no sanities were enabled, and RifleTech(+) was enabled.